### PR TITLE
Add a support for DynamicOS font assets

### DIFF
--- a/Packages/com.starasgames.tmpro-dynamic-data-cleaner/Editor/DynamicFontAssetAutoCleaner.cs
+++ b/Packages/com.starasgames.tmpro-dynamic-data-cleaner/Editor/DynamicFontAssetAutoCleaner.cs
@@ -39,7 +39,7 @@ namespace TMProDynamicDataCleaner.Editor
                     if (fontAsset == null)
                         continue;
 
-                    if (fontAsset.atlasPopulationMode != AtlasPopulationMode.Dynamic)
+                    if (fontAsset.atlasPopulationMode != AtlasPopulationMode.Dynamic && fontAsset.atlasPopulationMode != AtlasPopulationMode.DynamicOS)
                         continue;
 
                     // Debug.Log("Clearing font asset data at " + path);


### PR DESCRIPTION
I added support for font assets with AtlasPopulationMode set to `Dynamic OS` . It works correctly in my environment (Unity 6000.0.48f1).