### PR TITLE
Fix compilation error in older Unity versions

### DIFF
--- a/Packages/com.starasgames.tmpro-dynamic-data-cleaner/Editor/DynamicFontAssetAutoCleaner.cs
+++ b/Packages/com.starasgames.tmpro-dynamic-data-cleaner/Editor/DynamicFontAssetAutoCleaner.cs
@@ -39,9 +39,15 @@ namespace TMProDynamicDataCleaner.Editor
                     if (fontAsset == null)
                         continue;
 
-                    if (fontAsset.atlasPopulationMode != AtlasPopulationMode.Dynamic && fontAsset.atlasPopulationMode != AtlasPopulationMode.DynamicOS)
-                        continue;
+#if UNITY_2022_1_OR_NEWER
+                    bool isDynamic = fontAsset.atlasPopulationMode is AtlasPopulationMode.Dynamic or AtlasPopulationMode.DynamicOS;
+#else
+                    bool isDynamic = fontAsset.atlasPopulationMode is AtlasPopulationMode.Dynamic;
+#endif
 
+                    if (!isDynamic)
+                        continue;
+                        
                     // Debug.Log("Clearing font asset data at " + path);
                     fontAsset.ClearFontAssetData(setAtlasSizeToZero: true);
                 }


### PR DESCRIPTION
Hello! Just to let you know that this change introduced a compilation error in older Unity versions (such as 2021.3):

https://github.com/STARasGAMES/tmpro-dynamic-data-cleaner/commit/002255bb87667751d7d9101cfb7bce7cda644c1e

I added a pragma to only check for DynamicOS in 2022.1 onwards.