### PR TITLE
Added support for Textcore.Text.FontAsset

### DIFF
--- a/Packages/com.starasgames.tmpro-dynamic-data-cleaner/Editor/DynamicFontAssetAutoCleaner.cs
+++ b/Packages/com.starasgames.tmpro-dynamic-data-cleaner/Editor/DynamicFontAssetAutoCleaner.cs
@@ -11,7 +11,10 @@ using System;
 using TMPro;
 using UnityEditor;
 using UnityEngine;
+
+#if UNITY_2021_2_OR_NEWER
 using UnityEngine.TextCore.Text;
+#endif
 
 namespace TMProDynamicDataCleaner.Editor
 {


### PR DESCRIPTION
Textcore.Text.FontAsset is almost identical to TMP_FontAssets and has the same issue with dynamic data.
(Why they are not unified is unclear to me)
I added support to clear this data, tested in unity version 6000.0.59f2